### PR TITLE
Add resolver to search events by name, using pagination

### DIFF
--- a/api/src/resolvers/event.js
+++ b/api/src/resolvers/event.js
@@ -12,6 +12,46 @@ async function queryEventByID(id) {
     });
 }
 
+async function searchEvents(searchString, limit, offset) {
+  searchTokens = searchString.toLowerCase().split(" ");
+  const events = [];
+
+  let queryString = `
+    SELECT  *
+    FROM event
+    WHERE LOWER(name) LIKE '%' || ? || '%'`;
+  const vals = [searchTokens[0]];
+  searchTokens.pop();
+
+  searchTokens.forEach(token => {
+    queryString = `${queryString}
+      AND LOWER(name) LIKE '%' || ? || '%'`;
+    vals.push(token);
+  });
+
+  queryString = `${queryString} LIMIT ? OFFSET ?;`;
+  vals.push(limit, offset);
+  const res = await db.raw(queryString, vals);
+
+  res.rows.forEach(event => {
+    events.push({
+      id: event.id,
+      creator_id: event.creator_id,
+      name: event.name,
+      description: event.description,
+      start_time: event.start_time,
+      end_time: event.end_time,
+      capacity_type: event.capacity_type,
+      max_capacity: event.max_capacity,
+      current_capacity: event.current_capacity,
+      location: event.location,
+      picture_path: event.picture_path
+    });
+  });
+
+  return events;
+}
+
 /*async function getMyEvents(user_id, event_type = null) {
   var querystring;
   if (event_type) {
@@ -30,4 +70,4 @@ async function queryEventByID(id) {
 }
 
 */
-module.exports = { queryEventByID };
+module.exports = { queryEventByID, searchEvents };

--- a/api/src/resolvers/index.js
+++ b/api/src/resolvers/index.js
@@ -1,5 +1,5 @@
 const { signIn, searchUsers } = require("./user");
-const { queryEventByID } = require("./event");
+const { queryEventByID, searchEvents } = require("./event");
 const { querySeminarByID } = require("./seminar");
 
 const rootResolvers = {
@@ -41,6 +41,15 @@ const rootResolvers = {
       } catch (err) {
         console.log(err);
         return new Error("Unable to search users");
+      }
+    },
+    async searchEventsByName(_, args) {
+      const { searchString, limit, offset } = args;
+      try {
+        return await searchEvents(searchString, limit, offset);
+      } catch (err) {
+        console.log(err);
+        return new Error("Unable to search events");
       }
     }
   },

--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -20,6 +20,8 @@ const SchemaDefinition = `
     getEventByID(id: Int!): Event
     getSeminarByID(id: Int!): Seminar
     searchUsersByName(searchString: String!): [User!]
+
+    searchEventsByName(searchString: String!, limit: Int!, offset: Int!): [Event!]
   }
 
   # The schema allows the following mutations:


### PR DESCRIPTION
Add resolver `searchEventsByName` and helper function `searchEvents`
- takes a search string, and a limit and offset (for pagination)
- searches events by name and returns a list of Event type
- tokenizes the string and looks for events that have names with *all* tokens in them (aka. AND operator)

closes #11 