### PR TITLE
Search seminars

### DIFF
--- a/api/src/resolvers/event.js
+++ b/api/src/resolvers/event.js
@@ -12,7 +12,7 @@ async function queryEventByID(id) {
     });
 }
 
-async function searchEvents(searchString, limit, offset) {
+async function searchEvents(searchString, limit = null, offset = null) {
   searchTokens = searchString.toLowerCase().split(" ");
   const events = [];
 
@@ -29,8 +29,16 @@ async function searchEvents(searchString, limit, offset) {
     vals.push(token);
   });
 
-  queryString = `${queryString} LIMIT ? OFFSET ?;`;
-  vals.push(limit, offset);
+  if (limit) {
+    queryString = `${queryString} LIMIT ?`;
+    vals.push(limit);
+  }
+  if (offset) {
+    queryString = `${queryString} OFFSET ?`;
+    vals.push(offset);
+  }
+  queryString = `${queryString};`;
+
   const res = await db.raw(queryString, vals);
 
   res.rows.forEach(event => {

--- a/api/src/resolvers/index.js
+++ b/api/src/resolvers/index.js
@@ -1,6 +1,6 @@
 const { signIn, searchUsers } = require("./user");
 const { queryEventByID, searchEvents } = require("./event");
-const { querySeminarByID } = require("./seminar");
+const { querySeminarByID, searchSeminars } = require("./seminar");
 
 const rootResolvers = {
   Query: {
@@ -50,6 +50,15 @@ const rootResolvers = {
       } catch (err) {
         console.log(err);
         return new Error("Unable to search events");
+      }
+    },
+    async searchSeminarsByName(_, args) {
+      const { searchString, limit, offset } = args;
+      try {
+        return await searchSeminars(searchString, limit, offset);
+      } catch (err) {
+        console.log(err);
+        return new Error("Unable to search seminars");
       }
     }
   },

--- a/api/src/resolvers/seminar.js
+++ b/api/src/resolvers/seminar.js
@@ -12,4 +12,52 @@ async function querySeminarByID(id) {
     });
 }
 
-module.exports = { querySeminarByID };
+async function searchSeminars(searchString, limit = null, offset = null) {
+  searchTokens = searchString.toLowerCase().split(" ");
+  const seminars = [];
+
+  let queryString = `
+    SELECT  *
+    FROM seminar
+    WHERE LOWER(name) LIKE '%' || ? || '%'`;
+  const vals = [searchTokens[0]];
+  searchTokens.pop();
+
+  searchTokens.forEach(token => {
+    queryString = `${queryString}
+      AND LOWER(name) LIKE '%' || ? || '%'`;
+    vals.push(token);
+  });
+
+  if (limit) {
+    queryString = `${queryString} LIMIT ?`;
+    vals.push(limit);
+  }
+  if (offset) {
+    queryString = `${queryString} OFFSET ?`;
+    vals.push(offset);
+  }
+  queryString = `${queryString};`;
+
+  const res = await db.raw(queryString, vals);
+
+  res.rows.forEach(seminar => {
+    seminars.push({
+      id: seminar.id,
+      event_id: seminar.event_id,
+      name: seminar.name,
+      description: seminar.description,
+      start_time: seminar.start_time,
+      end_time: seminar.end_time,
+      capacity_type: seminar.capacity_type,
+      max_capacity: seminar.max_capacity,
+      current_capacity: seminar.current_capacity,
+      location: seminar.location,
+      picture_path: seminar.picture_path
+    });
+  });
+
+  return seminars;
+}
+
+module.exports = { querySeminarByID, searchSeminars };

--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -22,6 +22,7 @@ const SchemaDefinition = `
     searchUsersByName(searchString: String!): [User!]
 
     searchEventsByName(searchString: String!, limit: Int, offset: Int): [Event!]
+    searchSeminarsByName(searchString: String!, limit: Int, offset: Int): [Seminar!]
   }
 
   # The schema allows the following mutations:

--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -21,7 +21,7 @@ const SchemaDefinition = `
     getSeminarByID(id: Int!): Seminar
     searchUsersByName(searchString: String!): [User!]
 
-    searchEventsByName(searchString: String!, limit: Int!, offset: Int!): [Event!]
+    searchEventsByName(searchString: String!, limit: Int, offset: Int): [Event!]
   }
 
   # The schema allows the following mutations:


### PR DESCRIPTION
Update `searchEventsByName` resolver
- limit and offset values are now optional. The client can supply an offset, a limit, both, or neither

Add resolver `searchSeminarsByName` and helper function `searchEvents`
- takes a search string, and *optional* limit and offset values (for pagination)
- searches seminars by name and returns a list of Seminar type
- tokenizes the string and looks for seminars that have names with *all* tokens in them (aka. AND operator)

closes #12 