### PR TITLE
Add resolver to get my events/seminars/both

### DIFF
--- a/api/src/resolvers/index.js
+++ b/api/src/resolvers/index.js
@@ -2,7 +2,11 @@ const { signIn, searchUsers } = require("./user");
 const { queryEventByID } = require("./event");
 const { querySeminarByID } = require("./seminar");
 const { queryAnnouncementByTypeID } = require("./announcement");
-const { searchEventsAndSeminars, getTotalCount } = require("./searchResults");
+const {
+  searchEventsAndSeminars,
+  getTotalCount,
+  getMySchedule
+} = require("./searchResults");
 
 const rootResolvers = {
   SearchResult: {
@@ -100,6 +104,22 @@ const rootResolvers = {
         console.log(err);
         if (!type) return new Error("Unable to search events and seminars.");
         return new Error(`Unable to search ${type}s.`);
+      }
+    },
+    async getMyEventsAndSeminars(_, args) {
+      const { userID, type, limit, offset, participationType } = args;
+      try {
+        return await getMySchedule(
+          userID,
+          type,
+          limit,
+          offset,
+          participationType
+        );
+      } catch (err) {
+        console.log(err);
+        if (!type) return new Error("Unable to My Events and My Seminars.");
+        return new Error(`Unable to get My ${type}s.`);
       }
     }
   },

--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -19,7 +19,7 @@ const SchemaDefinition = `
     getTotal(type: String): Int!
     getTotalSearchResults(searchString: String!, type: String): Int!
 
-""" time is returned as a utc time, you can convert it back using
+    """ time is returned as a utc time, you can convert it back using
     new Date(1571567400000)"""
     getEventByID(id: Int! offset: Int limit: Int): Event
     getSeminarByID(id: Int! offset: Int limit: Int): Seminar
@@ -27,6 +27,8 @@ const SchemaDefinition = `
 
     """ Search for events of seminars by name """
     searchByName(searchString: String!, type: String, limit: Int, offset: Int): [SearchResult!]
+
+    getMyEventsAndSeminars(userID: Int!, type: String, limit: Int, offset: Int, participationType: participation_type): [SearchResult!]
   }
 
   # The schema allows the following mutations:


### PR DESCRIPTION
Create a resolver to get My Events page for a given user: `getMyEventsAndSeminars()`
- requires `userID`
- option `offset` and `limit` for pagination
- optional `type` for event or seminar. If no type, will return both
- optional `participationType` for ATTENDING or FOLLOWING. If no participation type, will return both following and attending