### PR TITLE
Detect calendar conflicts

### DIFF
--- a/api/src/resolvers/index.js
+++ b/api/src/resolvers/index.js
@@ -168,8 +168,8 @@ const rootResolvers = {
     },
     async checkCalendarConflicts(_, args) {
       try {
-        const { userID, eventID, startDateTime, endDateTime } = args;
-        return checkConflicts(userID, eventID, startDateTime, endDateTime);
+        const { userID, type, startDateTime, endDateTime } = args;
+        return checkConflicts(userID, type, startDateTime, endDateTime);
       } catch (err) {
         console.log(err);
         return new Error(

--- a/api/src/resolvers/user.js
+++ b/api/src/resolvers/user.js
@@ -91,23 +91,33 @@ async function searchUsers(searchString) {
   return users;
 }
 
-async function checkConflicts(userID, eventID, startDateTime, endDateTime) {
+async function checkConflicts(userID, type, startDateTime, endDateTime) {
   const start = new Date(startDateTime);
   const end = new Date(endDateTime);
 
-  var userEventsAndSeminars = await getMySchedule(
-    userID,
-    null,
-    null,
-    null,
-    "ATTENDING"
-  );
+  let userEventsOrSeminars;
 
-  for (var i = 0; i < userEventsAndSeminars.length; i++) {
-    if (eventID && userEventsAndSeminars[i].id === eventID) continue;
+  if (type.toLowerCase() === "event") {
+    userEventsOrSeminars = await getMySchedule(
+      userID,
+      "event",
+      null,
+      null,
+      "ATTENDING"
+    );
+  } else if (type.toLowerCase() === "seminar") {
+    userEventsOrSeminars = await getMySchedule(
+      userID,
+      "seminar",
+      null,
+      null,
+      "ATTENDING"
+    );
+  }
 
-    var currStart = new Date(userEventsAndSeminars[i].start_time);
-    var currEnd = new Date(userEventsAndSeminars[i].end_time);
+  for (var i = 0; i < userEventsOrSeminars.length; i++) {
+    var currStart = new Date(userEventsOrSeminars[i].start_time);
+    var currEnd = new Date(userEventsOrSeminars[i].end_time);
 
     if (
       (currStart >= start && currStart <= end) ||

--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -35,7 +35,7 @@ const SchemaDefinition = `
     getMyManagingEventsAndSeminars(userID: Int!, type: String, limit: Int, offset: Int): [SearchResult!]
     getMyAnnouncements(userID: Int!, limit: Int, offset: Int): [Announcement!]
 
-    checkCalendarConflicts(userID: Int!, eventID: Int, startDateTime: String!, endDateTime: String!): Boolean
+    checkCalendarConflicts(userID: Int!, type: String!, startDateTime: String!, endDateTime: String!): Boolean
   }
 
   # The schema allows the following mutations:


### PR DESCRIPTION
New resolver `checkCalendarConflicts`
- accepts `userID` (of type integer), `type` (of type String), `startDateTime` (of type string), and `endDateTime` (of type string)
- all parameters are required
- client/ front end will call this function when a user wants to attend an event/seminar
  - send the user ID, type ("event" or "seminar"), the start and end dates of the event/seminar they want to attend
  - it will check the seminar that the user wants to attend against all other seminars that the user is attending, OR it will check the event that the user wants to attend against all other events that the user is attending
  - if a seminar conflicts with an event that the user is attending, then this will not count as a conflicting seminar since the user should have already been notified of the conflict when they clicked attend on the parent event
  - if there are conflicts, it will return `true`. Otherwise, `false`

  **Example**
   ```
   {
     checkCalendarConflicts(userID: 3, type: "seminar", startDateTime: "October 3 2018, 15:30", endDateTime: "October 4 2018, 8:30")
   }
   ```
   or
   ```
   {
     checkCalendarConflicts(userID: 3,  type: "event", startDateTime: "2018-10-03 15:30", endDateTime: "2018-10-13 15:30")
   }
   ```